### PR TITLE
fix: replace Bun.deepEquals with fast-deep-equal for Node.js compat

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
         "@graphql-typed-document-node/core": "^3.2.0",
         "commander": "^14.0.3",
         "dotenv": "^17.3.1",
+        "fast-deep-equal": "^3.1.3",
         "graphql": "^16.10.0",
         "graphql-request": "^7.1.2",
         "yaml": "^2.7.0",
@@ -320,6 +321,8 @@
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
     "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tachyon-gg/railway-deploy",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "repository": {
     "type": "git",
@@ -35,6 +35,7 @@
     "@graphql-typed-document-node/core": "^3.2.0",
     "commander": "^14.0.3",
     "dotenv": "^17.3.1",
+    "fast-deep-equal": "^3.1.3",
     "graphql": "^16.10.0",
     "graphql-request": "^7.1.2",
     "yaml": "^2.7.0",

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,9 @@
+import equal from "fast-deep-equal";
+
 /**
  * Deep equality comparison for objects, arrays, and primitives.
- * Order-independent for object keys. Uses Bun's built-in implementation.
+ * Order-independent for object keys.
  */
 export function deepEqual(a: unknown, b: unknown): boolean {
-  return Bun.deepEquals(a, b);
+  return equal(a, b);
 }


### PR DESCRIPTION
## Summary

- Replace `Bun.deepEquals` with `fast-deep-equal` (zero-dep, MIT) so the published package works on Node.js
- Bump version to 0.2.1

Closes #9

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test --bail test/*.test.ts` — 222 tests pass
- [x] `bun run build && node dist/index.js --help` — works on Node.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)