### PR TITLE
refactor: consolidate format.ts into single describeChange function

### DIFF
--- a/src/reconcile/format.ts
+++ b/src/reconcile/format.ts
@@ -208,12 +208,6 @@ const ACTION_ICON: Record<Action, (noColor: boolean) => string> = {
   delete: (nc) => red("-", nc),
 };
 
-const CATEGORY_HEADER_ICON: Record<Action, (noColor: boolean) => string> = {
-  create: (nc) => green("+", nc),
-  update: (nc) => yellow("~", nc),
-  delete: (nc) => red("-", nc),
-};
-
 /**
  * Print a human-readable summary of the changeset to stdout.
  *
@@ -243,24 +237,27 @@ export function printChangeset(
   console.log(`\nChangeset (${changeset.changes.length} changes):\n`);
 
   // Group changes by category, preserving order of first appearance
-  const groups = new Map<string, Change[]>();
+  const groups = new Map<string, Array<{ change: Change; desc: ChangeDescription }>>();
   for (const change of changeset.changes) {
-    const { category } = describeChange(change);
-    if (!groups.has(category)) groups.set(category, []);
-    groups.get(category)?.push(change);
+    const desc = describeChange(change);
+    let group = groups.get(desc.category);
+    if (!group) {
+      group = [];
+      groups.set(desc.category, group);
+    }
+    group.push({ change, desc });
   }
 
   // Print each group
-  for (const [category, changes] of groups) {
+  for (const [category, entries] of groups) {
     // Determine the dominant action for the category header
-    const actions = new Set(changes.map((c) => describeChange(c).action));
+    const actions = new Set(entries.map((e) => e.desc.action));
     const headerAction: Action = actions.size === 1 ? [...actions][0] : "update";
-    const headerIcon = CATEGORY_HEADER_ICON[headerAction](noColor);
+    const headerIcon = ACTION_ICON[headerAction](noColor);
 
     console.log(`  ${headerIcon} ${category.toUpperCase()}:`);
 
-    for (const change of changes) {
-      const desc = describeChange(change);
+    for (const { change, desc } of entries) {
       const icon = ACTION_ICON[desc.action](noColor);
 
       // Verbose details for specific change types
@@ -298,15 +295,16 @@ export function printChangeset(
     console.log();
   }
 
-  // Summary line
+  // Summary line (reuse cached descriptions)
   let createCount = 0;
   let updateCount = 0;
   let deleteCount = 0;
-  for (const change of changeset.changes) {
-    const { action } = describeChange(change);
-    if (action === "create") createCount++;
-    else if (action === "update") updateCount++;
-    else deleteCount++;
+  for (const entries of groups.values()) {
+    for (const { desc } of entries) {
+      if (desc.action === "create") createCount++;
+      else if (desc.action === "update") updateCount++;
+      else deleteCount++;
+    }
   }
 
   const parts: string[] = [];

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -42,6 +42,24 @@ describe("changeLabel", () => {
         mustContain: ["create-service", "node:20", "branch: main"],
       },
       {
+        change: {
+          type: "create-service",
+          name: "db",
+          source: { image: "postgres:16" },
+          volume: { mount: "/data", name: "pg-data" },
+        },
+        mustContain: ["create-service", "postgres:16", "volume: /data"],
+      },
+      {
+        change: {
+          type: "create-service",
+          name: "cron",
+          source: { image: "alpine" },
+          cronSchedule: "*/5 * * * *",
+        },
+        mustContain: ["create-service", "alpine", "cron: */5 * * * *"],
+      },
+      {
         change: { type: "delete-service", name: "old", serviceId: "svc-1" },
         mustContain: ["delete-service", "old", "svc-1"],
       },


### PR DESCRIPTION
## Summary

- Replace parallel switch statements in `changeLabel` and `printChangeset` with a single `describeChange()` function that returns `{ category, action, summary }`
- New change types only need to be added in one place
- `printChangeset` now groups by category dynamically instead of manually filtering each type

Fixes missing information in diff output:
- Domain `targetPort` now shown in create-domain
- Volume ID shown in delete-volume
- TCP proxy ID shown in delete-tcp-proxy
- Service limits details shown in labels
- Create-service shows branch, volume, cron details

Closes #11

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test --bail test/*.test.ts` — 204 tests pass
- [x] `bunx biome check src/ test/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)