### PR TITLE
fix: non-nullable Railway fields can't be cleared — skip diff and warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tachyon-gg/railway-deploy",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "type": "module",
   "repository": {
     "type": "git",

--- a/src/reconcile/diff.ts
+++ b/src/reconcile/diff.ts
@@ -353,7 +353,10 @@ function diffServiceSettings(
     desired.restartPolicyMaxRetries !== current.restartPolicyMaxRetries
   ) {
     settings.restartPolicyMaxRetries = desired.restartPolicyMaxRetries;
-  } else if (desired.restartPolicyMaxRetries === undefined && current.restartPolicyMaxRetries) {
+  } else if (
+    desired.restartPolicyMaxRetries === undefined &&
+    current.restartPolicyMaxRetries !== undefined
+  ) {
     console.warn(
       `  Warning: "${desired.name}" has no restart_policy_max_retries in config — Railway will keep ${current.restartPolicyMaxRetries}`,
     );

--- a/src/reconcile/diff.ts
+++ b/src/reconcile/diff.ts
@@ -315,8 +315,13 @@ function diffServiceSettings(
   if (!deepEqual(desired.source, current.source)) {
     settings.source = desired.source ?? null;
   }
-  if (desired.restartPolicy !== current.restartPolicy) {
-    settings.restartPolicy = desired.restartPolicy ?? null;
+  // restartPolicyType is non-nullable on Railway — can't clear it
+  if (desired.restartPolicy !== undefined && desired.restartPolicy !== current.restartPolicy) {
+    settings.restartPolicy = desired.restartPolicy;
+  } else if (desired.restartPolicy === undefined && current.restartPolicy) {
+    console.warn(
+      `  Warning: "${desired.name}" has no restart_policy in config — Railway will keep "${current.restartPolicy}"`,
+    );
   }
   if (!deepEqual(desired.healthcheck, current.healthcheck)) {
     settings.healthcheck = desired.healthcheck ?? null;
@@ -342,18 +347,39 @@ function diffServiceSettings(
   if (!deepEqual(desired.preDeployCommand, current.preDeployCommand)) {
     settings.preDeployCommand = desired.preDeployCommand ?? null;
   }
-  if (desired.restartPolicyMaxRetries !== current.restartPolicyMaxRetries) {
-    settings.restartPolicyMaxRetries = desired.restartPolicyMaxRetries ?? null;
+  // restartPolicyMaxRetries is non-nullable on Railway — can't clear it
+  if (
+    desired.restartPolicyMaxRetries !== undefined &&
+    desired.restartPolicyMaxRetries !== current.restartPolicyMaxRetries
+  ) {
+    settings.restartPolicyMaxRetries = desired.restartPolicyMaxRetries;
+  } else if (desired.restartPolicyMaxRetries === undefined && current.restartPolicyMaxRetries) {
+    console.warn(
+      `  Warning: "${desired.name}" has no restart_policy_max_retries in config — Railway will keep ${current.restartPolicyMaxRetries}`,
+    );
   }
   if (desired.sleepApplication !== current.sleepApplication) {
     settings.sleepApplication = desired.sleepApplication ?? null;
   }
   // Group 1 fields
-  if (desired.builder !== current.builder) {
-    settings.builder = desired.builder ?? null;
+  // builder is non-nullable on Railway — can't clear it
+  if (desired.builder !== undefined && desired.builder !== current.builder) {
+    settings.builder = desired.builder;
+  } else if (desired.builder === undefined && current.builder) {
+    console.warn(
+      `  Warning: "${desired.name}" has no builder in config — Railway will keep "${current.builder}"`,
+    );
   }
-  if (!deepEqual(desired.watchPatterns, current.watchPatterns)) {
-    settings.watchPatterns = desired.watchPatterns ?? null;
+  // watchPatterns is non-nullable on Railway — can't clear it
+  if (
+    desired.watchPatterns !== undefined &&
+    !deepEqual(desired.watchPatterns, current.watchPatterns)
+  ) {
+    settings.watchPatterns = desired.watchPatterns;
+  } else if (desired.watchPatterns === undefined && current.watchPatterns?.length) {
+    console.warn(
+      `  Warning: "${desired.name}" has no watch_patterns in config — Railway will keep current patterns`,
+    );
   }
   if (desired.drainingSeconds !== current.drainingSeconds) {
     settings.drainingSeconds = desired.drainingSeconds ?? null;

--- a/src/reconcile/diff.ts
+++ b/src/reconcile/diff.ts
@@ -318,7 +318,7 @@ function diffServiceSettings(
   // restartPolicyType is non-nullable on Railway — can't clear it
   if (desired.restartPolicy !== undefined && desired.restartPolicy !== current.restartPolicy) {
     settings.restartPolicy = desired.restartPolicy;
-  } else if (desired.restartPolicy === undefined && current.restartPolicy) {
+  } else if (desired.restartPolicy === undefined && current.restartPolicy !== undefined) {
     console.warn(
       `  Warning: "${desired.name}" has no restart_policy in config — Railway will keep "${current.restartPolicy}"`,
     );
@@ -368,7 +368,7 @@ function diffServiceSettings(
   // builder is non-nullable on Railway — can't clear it
   if (desired.builder !== undefined && desired.builder !== current.builder) {
     settings.builder = desired.builder;
-  } else if (desired.builder === undefined && current.builder) {
+  } else if (desired.builder === undefined && current.builder !== undefined) {
     console.warn(
       `  Warning: "${desired.name}" has no builder in config — Railway will keep "${current.builder}"`,
     );
@@ -379,7 +379,7 @@ function diffServiceSettings(
     !deepEqual(desired.watchPatterns, current.watchPatterns)
   ) {
     settings.watchPatterns = desired.watchPatterns;
-  } else if (desired.watchPatterns === undefined && current.watchPatterns?.length) {
+  } else if (desired.watchPatterns === undefined && current.watchPatterns !== undefined) {
     console.warn(
       `  Warning: "${desired.name}" has no watch_patterns in config — Railway will keep current patterns`,
     );

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -725,6 +725,34 @@ describe("computeChangeset", () => {
     expect(update).toBeUndefined();
   });
 
+  test("removing restartPolicyMaxRetries from config skips diff (even when 0)", () => {
+    const desired = makeState({
+      services: {
+        web: {
+          name: "web",
+          id: "svc-1",
+          variables: {},
+          domains: [],
+        },
+      },
+    });
+    const current = makeState({
+      services: {
+        web: {
+          name: "web",
+          id: "svc-1",
+          variables: {},
+          domains: [],
+          restartPolicyMaxRetries: 0,
+        },
+      },
+    });
+
+    const changeset = computeChangeset(desired, current, {}, [], {});
+    const update = changeset.changes.find((c) => c.type === "update-service-settings");
+    expect(update).toBeUndefined();
+  });
+
   test("removing source from config generates null clear", () => {
     const desired = makeState({
       services: {

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1231,6 +1231,7 @@ describe("computeChangeset", () => {
   });
 
   test("removing nullable fields clears them, non-nullable fields are skipped with warning", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const desired = makeState({
       services: {
         web: {
@@ -1269,6 +1270,10 @@ describe("computeChangeset", () => {
       expect(update.settings.overlapSeconds).toBeNull();
       expect(update.settings.ipv6EgressEnabled).toBeNull();
     }
+    // Warnings should fire for non-nullable fields
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("builder"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("watch_patterns"));
+    warnSpy.mockRestore();
   });
 
   // --- Group 2: Branch ---

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -696,7 +696,7 @@ describe("computeChangeset", () => {
     }
   });
 
-  test("removing restartPolicy from config generates null clear", () => {
+  test("removing restartPolicy from config skips diff but warns", () => {
     const desired = makeState({
       services: {
         web: {
@@ -720,11 +720,9 @@ describe("computeChangeset", () => {
     });
 
     const changeset = computeChangeset(desired, current, {}, [], {});
+    // Non-nullable field — no change generated, Railway keeps current value
     const update = changeset.changes.find((c) => c.type === "update-service-settings");
-    expect(update).toBeDefined();
-    if (update?.type === "update-service-settings") {
-      expect(update.settings.restartPolicy).toBeNull();
-    }
+    expect(update).toBeUndefined();
   });
 
   test("removing source from config generates null clear", () => {
@@ -1198,7 +1196,7 @@ describe("computeChangeset", () => {
     }
   });
 
-  test("removing builder/watchPatterns/etc from config generates null clear", () => {
+  test("removing nullable fields clears them, non-nullable fields are skipped with warning", () => {
     const desired = makeState({
       services: {
         web: {
@@ -1229,8 +1227,10 @@ describe("computeChangeset", () => {
     const update = changeset.changes.find((c) => c.type === "update-service-settings");
     expect(update).toBeDefined();
     if (update?.type === "update-service-settings") {
-      expect(update.settings.builder).toBeNull();
-      expect(update.settings.watchPatterns).toBeNull();
+      // Non-nullable fields (builder, watchPatterns) should NOT be in settings
+      expect(update.settings.builder).toBeUndefined();
+      expect(update.settings.watchPatterns).toBeUndefined();
+      // Nullable fields should be cleared
       expect(update.settings.drainingSeconds).toBeNull();
       expect(update.settings.overlapSeconds).toBeNull();
       expect(update.settings.ipv6EgressEnabled).toBeNull();

--- a/test/diff.test.ts
+++ b/test/diff.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { computeChangeset } from "../src/reconcile/diff.js";
 import type { State } from "../src/types/state.js";
 
@@ -697,6 +697,7 @@ describe("computeChangeset", () => {
   });
 
   test("removing restartPolicy from config skips diff but warns", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const desired = makeState({
       services: {
         web: {
@@ -720,12 +721,15 @@ describe("computeChangeset", () => {
     });
 
     const changeset = computeChangeset(desired, current, {}, [], {});
-    // Non-nullable field — no change generated, Railway keeps current value
     const update = changeset.changes.find((c) => c.type === "update-service-settings");
     expect(update).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("restart_policy"));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ALWAYS"));
+    warnSpy.mockRestore();
   });
 
-  test("removing restartPolicyMaxRetries from config skips diff (even when 0)", () => {
+  test("removing restartPolicyMaxRetries from config skips diff and warns (even when 0)", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
     const desired = makeState({
       services: {
         web: {
@@ -751,6 +755,8 @@ describe("computeChangeset", () => {
     const changeset = computeChangeset(desired, current, {}, [], {});
     const update = changeset.changes.find((c) => c.type === "update-service-settings");
     expect(update).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("restart_policy_max_retries"));
+    warnSpy.mockRestore();
   });
 
   test("removing source from config generates null clear", () => {


### PR DESCRIPTION
## Summary

`restartPolicy`, `restartPolicyMaxRetries`, `builder`, and `watchPatterns` are non-nullable on Railway — sending null is silently ignored, creating false diffs that never resolve.

Now: only diff these when explicitly set in config. If absent from config but present on Railway, warn the user that Railway will keep the current value.

Bumps to v0.2.7.

Closes #21

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test --bail test/*.test.ts` — 225 tests pass
- [x] `bunx biome check src/ test/` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)