### PR TITLE
fix: mutation timeouts, DOCKERFILE builder, error output

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ registry_credentials:              # For private container registries
 #### Build
 
 ```yaml
-builder: NIXPACKS                  # RAILPACK (default), DOCKERFILE, NIXPACKS, HEROKU, PAKETO
+builder: NIXPACKS                  # RAILPACK (default), NIXPACKS, HEROKU, PAKETO
 build_command: npm run build       # Custom build command
-dockerfile_path: Dockerfile.prod   # Path to Dockerfile (when builder is DOCKERFILE)
+dockerfile_path: Dockerfile.prod   # Path to Dockerfile (uses Railpack with Dockerfile)
 root_directory: /packages/api      # Root directory (monorepo support)
 watch_patterns:                    # File patterns that trigger deploys
   - /packages/api/src/**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tachyon-gg/railway-deploy",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "type": "module",
   "repository": {
     "type": "git",

--- a/schemas/environment.schema.json
+++ b/schemas/environment.schema.json
@@ -121,7 +121,7 @@
         "builder": {
           "type": "string",
           "description": "Builder to use for deployments.",
-          "enum": ["RAILPACK", "DOCKERFILE", "NIXPACKS", "HEROKU", "PAKETO"]
+          "enum": ["RAILPACK", "NIXPACKS", "HEROKU", "PAKETO"]
         },
         "watch_patterns": {
           "type": "array",

--- a/schemas/service-template.schema.json
+++ b/schemas/service-template.schema.json
@@ -140,7 +140,7 @@
     "builder": {
       "type": "string",
       "description": "Builder to use for deployments.",
-      "enum": ["RAILPACK", "DOCKERFILE", "NIXPACKS", "HEROKU", "PAKETO"]
+      "enum": ["RAILPACK", "NIXPACKS", "HEROKU", "PAKETO"]
     },
     "watch_patterns": {
       "type": "array",

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -175,7 +175,7 @@ export function validateServiceTemplate(data: unknown, templatePath: string): vo
 // --- Value validation (run after param expansion on resolved ServiceState) ---
 
 const VALID_RESTART_POLICIES = ["ALWAYS", "NEVER", "ON_FAILURE"];
-const VALID_BUILDERS = ["RAILPACK", "DOCKERFILE", "NIXPACKS", "HEROKU", "PAKETO"];
+const VALID_BUILDERS = ["RAILPACK", "NIXPACKS", "HEROKU", "PAKETO"];
 const CRON_FIELD_PATTERN = /^(\*|[0-9]+(-[0-9]+)?(,[0-9]+(-[0-9]+)?)*)(\/[0-9]+)?$/;
 const DOMAIN_PATTERN = /^(\*\.)?[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
 

--- a/src/railway/client.ts
+++ b/src/railway/client.ts
@@ -11,7 +11,7 @@ export function createClient(token: string): GraphQLClient {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-    signal: AbortSignal.timeout(30_000),
+    signal: AbortSignal.timeout(120_000),
   });
 
   // Wrap the request method with retry logic

--- a/src/railway/client.ts
+++ b/src/railway/client.ts
@@ -11,13 +11,15 @@ export function createClient(token: string): GraphQLClient {
     headers: {
       Authorization: `Bearer ${token}`,
     },
-    signal: AbortSignal.timeout(120_000),
   });
 
-  // Wrap the request method with retry logic
+  // Wrap the request method with retry logic and a fresh per-request timeout
   const originalRequest = baseClient.request.bind(baseClient);
   baseClient.request = ((...args: Parameters<typeof originalRequest>) =>
-    withRetry(() => originalRequest(...args))) as typeof originalRequest;
+    withRetry(() => {
+      baseClient.requestConfig.signal = AbortSignal.timeout(120_000);
+      return originalRequest(...args);
+    })) as typeof originalRequest;
 
   return baseClient;
 }

--- a/src/reconcile/apply.ts
+++ b/src/reconcile/apply.ts
@@ -38,6 +38,20 @@ interface ApplyOptions {
   noColor?: boolean;
 }
 
+/** Extract a clean error message from GraphQL or network errors */
+function extractErrorMessage(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const msg = err.message;
+  // GraphQL errors contain JSON with a "message" field — extract it
+  const match = msg.match(/"message":"([^"]+)"/);
+  if (match && match[1] !== "Problem processing request") return match[1];
+  // For generic "Problem processing request", include the input for debugging
+  const inputMatch = msg.match(/"input":(\{[^}]+\})/);
+  if (match && inputMatch) return `${match[1]} — input: ${inputMatch[1]}`;
+  if (match) return match[1];
+  return msg;
+}
+
 // ANSI color helpers (used in apply output)
 function green(text: string, noColor: boolean): string {
   return noColor ? text : `\x1b[32m${text}\x1b[0m`;
@@ -98,7 +112,7 @@ export async function applyChangeset(
       applied.push(change);
       console.log(`  ${green("✓", noColor)} ${changeLabel(change)}`);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
+      const message = extractErrorMessage(err);
       failed.push({ change, error: message });
       console.log(`  ${red("✗", noColor)} ${changeLabel(change)} — ${message}`);
     }

--- a/src/reconcile/apply.ts
+++ b/src/reconcile/apply.ts
@@ -42,12 +42,23 @@ interface ApplyOptions {
 function extractErrorMessage(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
   const msg = err.message;
-  // GraphQL errors contain JSON with a "message" field — extract it
+
+  // Try to parse structured GraphQL error response
+  try {
+    const parsed = "response" in err ? (err as { response: unknown }).response : undefined;
+    if (parsed && typeof parsed === "object" && parsed !== null) {
+      const resp = parsed as { errors?: Array<{ message: string }>; body?: string };
+      const gqlMessage = resp.errors?.[0]?.message;
+      if (gqlMessage && gqlMessage !== "Problem processing request") {
+        return gqlMessage;
+      }
+    }
+  } catch {
+    // Fall through to regex extraction
+  }
+
+  // Fallback: extract "message" from stringified error
   const match = msg.match(/"message":"([^"]+)"/);
-  if (match && match[1] !== "Problem processing request") return match[1];
-  // For generic "Problem processing request", include the input for debugging
-  const inputMatch = msg.match(/"input":(\{[^}]+\})/);
-  if (match && inputMatch) return `${match[1]} — input: ${inputMatch[1]}`;
   if (match) return match[1];
   return msg;
 }


### PR DESCRIPTION
## Summary

- Increase API timeout from 30s to 120s for mutations (service create/delete were timing out)
- Remove DOCKERFILE from valid builders — not a Railway enum value. Dockerfile builds use `dockerfile_path` with RAILPACK builder
- Extract clean error messages from GraphQL responses instead of dumping raw JSON
- Update README to clarify Dockerfile build configuration

Bumps to v0.2.9.

Closes #25

## Test plan

- [x] `bun run typecheck` — passes
- [x] `bun test --bail test/*.test.ts` — 231 tests pass
- [x] Tested against real Railway project — 7/7 mutations succeeded, no timeouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)