### PR TITLE
fix: resolve projects under workspaces (legacy top-level projects query is empty for workspace-scoped accounts)

### DIFF
--- a/src/railway/queries.ts
+++ b/src/railway/queries.ts
@@ -6,26 +6,59 @@ import {
   GetPrivateNetworksDocument,
   GetProjectDocument,
   GetTcpProxiesDocument,
-  ListProjectsDocument,
 } from "../generated/graphql.js";
 import { logger } from "../logger.js";
 import type { EnvironmentConfig } from "../types/envconfig.js";
 
+interface ProjectNode {
+  id: string;
+  name: string;
+}
+interface ProjectEdges {
+  edges: Array<{ node: ProjectNode }>;
+}
+interface ListProjectsCompat {
+  me?: {
+    workspaces?: Array<{ projects?: ProjectEdges }>;
+    projects?: ProjectEdges;
+  };
+}
+
+// Railway migrated projects under workspaces, so the legacy top-level `projects`
+// query returns an empty list for any workspace-scoped account. Query the
+// workspace-nested projects (keeping the user-level list as a fallback for older
+// accounts), so a personal/CLI token resolves the project correctly.
+const LIST_PROJECTS_COMPAT = /* GraphQL */ `
+  query ListProjectsCompat {
+    me {
+      workspaces { projects { edges { node { id name } } } }
+      projects { edges { node { id name } } }
+    }
+  }
+`;
+
 /**
- * Resolve a project name to its ID.
+ * Resolve a project name (or id) to its ID.
  */
 export async function resolveProjectId(
   client: GraphQLClient,
   projectName: string,
 ): Promise<string> {
-  const data = await client.request(ListProjectsDocument);
+  const data = await client.request<ListProjectsCompat>(LIST_PROJECTS_COMPAT);
 
-  const project = data.projects.edges.find((e) => e.node.name === projectName);
+  const nodes: ProjectNode[] = [
+    ...(data.me?.workspaces ?? []).flatMap((w) => w.projects?.edges ?? []),
+    ...(data.me?.projects?.edges ?? []),
+  ].map((e) => e.node);
+
+  const project = nodes.find(
+    (n) => n.name === projectName || n.id === projectName,
+  );
   if (!project) {
-    const available = data.projects.edges.map((e) => e.node.name).join(", ");
+    const available = nodes.map((n) => n.name).join(", ");
     throw new Error(`Project "${projectName}" not found. Available: ${available}`);
   }
-  return project.node.id;
+  return project.id;
 }
 
 /**


### PR DESCRIPTION
## Problem

`resolveProjectId` fails with `Project "<name>" not found. Available:` (empty list)
for any account whose projects live under a **workspace** — which is now the default
on Railway. The tool is unusable for these accounts: every run dies at project
resolution before any diff/apply.

## Root cause

`resolveProjectId` uses `ListProjectsDocument`, i.e. the legacy **top-level
`projects`** query:

```graphql
query ListProjects { projects { edges { node { id name } } } }
```

Since Railway migrated projects under workspaces, that top-level field returns an
empty connection for workspace-scoped tokens (the same token returns the projects
fine under `me.workspaces[].projects`). So `data.projects.edges` is `[]` and no
project ever matches.

## Fix

Resolve against `me.workspaces[].projects` (with the user-level `me.projects` list
kept as a fallback for older/personal accounts), and match by **name or id**:

```graphql
query ListProjectsCompat {
  me {
    workspaces { projects { edges { node { id name } } } }
    projects { edges { node { id name } } }
  }
}
```

No new token scope or permission is required — the existing token already authorizes
these fields. Downstream resolution is unchanged (everything else is `project(id:)`-scoped).

## Testing

Verified end-to-end against a live workspace-scoped account: dry-run and `--apply`
now resolve the project, diff correctly, and apply variable/branch/rootDir/domain
changes successfully. Before the patch the same config errored at
`Project "<name>" not found. Available:`.
